### PR TITLE
modified BooleanGenerator.java and ByteGenerator.java

### DIFF
--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/BooleanGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/BooleanGenerator.java
@@ -49,8 +49,6 @@ public class BooleanGenerator extends Generator<Boolean> {
         SourceOfRandomness random,
         GenerationStatus status) {
 
-        // return random.nextBoolean();
-
         float randomFloat = random.nextFloat(0.0f, 1.0f);
         return randomFloat > 0.5f;
     }

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/BooleanGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/BooleanGenerator.java
@@ -49,7 +49,10 @@ public class BooleanGenerator extends Generator<Boolean> {
         SourceOfRandomness random,
         GenerationStatus status) {
 
-        return random.nextBoolean();
+        // return random.nextBoolean();
+
+        float randomFloat = random.nextFloat(0.0f, 1.0f);
+        return randomFloat > 0.5f;
     }
 
     @Override public List<Boolean> doShrink(

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/ByteGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/ByteGenerator.java
@@ -73,9 +73,7 @@ public class ByteGenerator extends IntegralGenerator<Byte> {
         SourceOfRandomness random,
         GenerationStatus status) {
 
-        // return random.nextByte(min, max);
         float randomFloat = random.nextFloat(0.0f, 1.0f);
-
         return (byte) (randomFloat * 255);
     }
 

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/ByteGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/lang/ByteGenerator.java
@@ -73,7 +73,10 @@ public class ByteGenerator extends IntegralGenerator<Byte> {
         SourceOfRandomness random,
         GenerationStatus status) {
 
-        return random.nextByte(min, max);
+        // return random.nextByte(min, max);
+        float randomFloat = random.nextFloat(0.0f, 1.0f);
+
+        return (byte) (randomFloat * 255);
     }
 
     @Override protected Function<BigInteger, Byte> narrow() {


### PR DESCRIPTION
I modified two files, which are BooleanGenerator.java and ByteGenerator.java.
They run fine when I do the normal test but fail when I use the nondex tool to test the flaky test. 
After looking it up, I found the code that caused the error:
`
return random.nextByte(min, max);
`
The expected method invocation was randomForParameterGenerator.nextFloat(0.0f, 1.0f);.However, this method was not invoked as expected. What was expected was a float with a range in (0.0f, 1.0f), but what was provided is a byte range in ((byte) 0x80, (byte) 0x7F). 

So what I have done is replace nextByte() with nextFloat(0.0f, 1.0f), and use (byte) (randomFloat * 255) to make sure it falls in the range.

Same for BooleanGenerator.java. Test the modified code again, including the nondex test, all pass now.
